### PR TITLE
Add DEPRECATED to readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,9 @@
 :toc:
 
+= DEPRECATED This repository is not used anymore =
+
+= It now lives in https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor =
+
 == Overview
 
 The Dark Tower repo contains the Ansible Playbooks and roles for the back-end component, Dark Tower, of the Ansible Babylon Tower Project. These are used for final configuration, and customization of a Ansible Tower cluster *and* also the core `job-runner` playbook and associated roles to allow a Babylon Tower to be remotely called to deploy, teardown, idle and start infrastructure using ansible based deployers such as link:https://github.com/redhat-cop/agnosticd.git[agnosticd] and link:https://github.com/ansible/workshops.git[ansible workshops].

--- a/job-runner.yml
+++ b/job-runner.yml
@@ -18,6 +18,7 @@
         ~ job_vars['guid']
       }}
     job_forks:                 "{{ job_vars['__meta__']['tower']['forks'] | default(10) }}"
+    job_template_timeout:      "{{ job_vars['__meta__']['tower']['timeout'] | default(3*60*60) }}"
     job_playbook:              "{{  job_vars['__meta__']['deployer']['entry_point'] }}"
     job_virtualenv:   "{{  job_vars['__meta__']['deployer']['virtualenv'] | default('') }}"
     _job_virtualenv: >-

--- a/roles/confirm-tower-job-template/tasks/main.yml
+++ b/roles/confirm-tower-job-template/tasks/main.yml
@@ -36,6 +36,7 @@
       playbook:                {{ job_playbook       | to_json }}
       custom_virtualenv:       {{ _job_virtualenv    | to_json }}
       forks:                   {{ job_forks          | to_json }}
+      timeout:                 {{ job_template_timeout | to_json }}
       job_type:                "run"
       allow_simultaneous:      True
       ask_inventory_on_launch: True


### PR DESCRIPTION
Set a default to 3h.

This can be changed in babylon meta var:

```yaml
__meta__:
  tower:
    timeout: 3600
```